### PR TITLE
Remove duplicate capybara gem line.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ gem 'jbuilder', '~> 2.5'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
-gem 'capybara'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console


### PR DESCRIPTION
-----> Ruby app detected
-----> Compiling Ruby/Rails
 !
 !     There was an error parsing your Gemfile, we cannot continue
 !     
Heroku deploy failed due to Capybara gem being included twice.  Removed one of the instances to allow deploy to continue.

 !     [!] There was an error parsing `Gemfile`: You cannot specify the same gem twice with different version requirements.
 !     You specified: capybara (>= 0) and capybara (>= 2.15). Bundler cannot continue.